### PR TITLE
Fix for date range check in report

### DIFF
--- a/app/controllers/sprint/report.js
+++ b/app/controllers/sprint/report.js
@@ -59,12 +59,13 @@ export default Ember.Controller.extend({
           for (var day = sprintBegin.clone(); !day.isAfter(sprintEnd); day = day.add(1, 'days'), daysTotal++) {
             data.labels.push(day.format('MMM D'));
             
+            var nextDay = day.clone().add(1, 'days');
             var storyPointsByBugId = {};
             _(response.result.bugs).forEachRight(function(historyByBug) {
               var bugId = historyByBug.id;
               
               _(historyByBug.history).forEachRight(function(history) {
-                if (!moment(history.when).isBetween(sprintBegin, day)) {
+                if (!moment(history.when).isBetween(sprintBegin, nextDay)) {
                   return;
                 }
                 var change = _.find(history.changes, function(change) {


### PR DESCRIPTION
The report graph was attributing story point burn down to one day past the current date. 

When checking each history element of a bug for inclusion, the date was compared between the beginning of the sprint and the 'day' value (the chart x-axis date). Since the moment function inBetween was used, it did not include the actual day in question, only the days before. The simple fix for this was to add a day to the 'day' value, so that the day in question would be included.